### PR TITLE
change healthcheck to 127.0.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,6 @@ HEALTHCHECK \
     --interval=5s \
     --timeout=30s \
     --retries=3 \
-    CMD nc -z localhost 8081 || exit 1
+    CMD nc -z 127.0.0.1 8081 || exit 1
 
 ENTRYPOINT ["/usr/local/bin/telegram-bot-api"]


### PR DESCRIPTION
Hey,

I've been using this container quite successfully for months now, however using `network_mode: host` seems to make my health check fail, marking it as unhealthy. This is probably due to the extra step of resolving `localhost` to `127.0.0.1`.

I couldn't build the image locally, but from my testing (attaching to `/bin/sh` inside the container) it achieves the desired result more reliably.

![image](https://github.com/user-attachments/assets/a87df3a8-a526-482b-8ec1-179444dd1741)

EDIT:
As a workaround you can override the healthcheck without rebuilding the image:
```yml
healthcheck:
  test: ["CMD-SHELL", "nc -z 127.0.0.1 8081 || exit 1"]
  interval: 5s
  timeout: 30s
  retries: 3
```